### PR TITLE
Give a link to the Kintone record detail page in the name field of the Gantt chart. #171

### DIFF
--- a/examples/ganttchart/js/desktop-ganttchart.js
+++ b/examples/ganttchart/js/desktop-ganttchart.js
@@ -363,6 +363,7 @@ function closeButton() {
             function createRecords1() {
                 for (var i2 = 0; i2 < records.length; i2++) {
                     var subTable = records[i2].Table.value;
+                    var record_url_path = '/k/' + kintone.app.getId() + '/show#record=' + records[i2]['$id']['value'];
 
                     for (var j = 0; j < subTable.length; j++) {
                         var colorGantt = self.settings.element.classColorGanttDefault;
@@ -404,7 +405,7 @@ function closeButton() {
 
                         var ganttRecordData = {
                             id: self.escapeHtml(records[i2]['$id'].value),
-                            name: (j !== 0) ? '' : self.escapeHtml(records[i2][GANTT_NAME].value),
+                            name: (j !== 0) ? '' : '<a href="' + record_url_path + '">' + self.escapeHtml(records[i2][GANTT_NAME].value) + '</a>',
                             desc:
                                 subTable[j].value[GANTT_DESC] ?
                                     self.escapeHtml(subTable[j].value[GANTT_DESC].value) : '',
@@ -416,7 +417,7 @@ function closeButton() {
                                     : self.escapeHtml(records[i2][GANTT_NAME].value),
                                 customClass: self.escapeHtml(colorGantt),
                                 dataObj: {
-                                    'url': '/k/' + kintone.app.getId() + '/show#record=' + records[i2]['$id']['value'],
+                                    'url': record_url_path,
                                     'name': records[i2][GANTT_NAME].value,
                                     'desc': deskFlg ? self.escapeHtml(subTable[j].value[GANTT_DESC].value) : '',
                                     'start': subTable[j].value[GANTT_FROM].value,
@@ -437,6 +438,7 @@ function closeButton() {
             function createRecords2() {
                 for (var i3 = 0; i3 < records.length; i3++) {
                     var colorGantt2 = self.settings.element.classColorGanttDefault;
+                    var record_url_path = '/k/' + kintone.app.getId() + '/show#record=' + records[i3]['$id']['value'];
 
                     var colorValue2 = records[i3][GANTT_COLOR]['value'] || '';
                     if (colorValue2 && self.settings.config.settingColors[colorValue2]) {
@@ -470,7 +472,7 @@ function closeButton() {
                     }
                     var ganttRecordData2 = {
                         id: self.escapeHtml(records[i3]['$id'].value),
-                        name: records[i3][GANTT_NAME] ? self.escapeHtml(records[i3][GANTT_NAME].value) : '',
+                        name: records[i3][GANTT_NAME] ? '<a href="' + record_url_path + '">' + self.escapeHtml(records[i3][GANTT_NAME].value) + '</a>' : '',
                         desc: records[i3][GANTT_DESC] ? self.escapeHtml(records[i3][GANTT_DESC].value) : '',
                         values: [{
                             from: self.convertDateTime(records[i3][GANTT_FROM].value),


### PR DESCRIPTION
the solution for https://github.com/kintone-samples/plugin-samples/issues/171
The name field in the Gantt Chart is linked.
The original plan was to toggle the linking on the settings page, but I thought that if the feature exists by default, there would be no need to turn it off.
![image](https://user-images.githubusercontent.com/6148951/101979977-1d133300-3ca5-11eb-8ff9-9abfc8d5a5b3.png)

