### PR TITLE
fix:index.delete.submit

### DIFF
--- a/examples/conditionformat2/js/desktop.js
+++ b/examples/conditionformat2/js/desktop.js
@@ -378,7 +378,7 @@ jQuery.noConflict();
     RECORDS = RECORDS.filter((record) => {
       return record.$id.value !== event.recordId;
     });
-
+    return event;
   });
 
   kintone.events.on('app.record.detail.show', (event) => {

--- a/examples/conditionformat2/manifest.json
+++ b/examples/conditionformat2/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 1,
-    "version": "3.2.5",
+    "version": "3.2.6",
     "type": "APP",
     "name": {
         "ja": "条件書式プラグイン",


### PR DESCRIPTION
Apart from the plugin, when canceling the deletion in [~index.delete.submit] with javascript, there was no return event, so the deletion went through as it was.