### PR TITLE
JSEditとJavaScript/CSSカスタマイズのライブラリの競合防止機能修正

### DIFF
--- a/examples/js-edit/js/config/main.js
+++ b/examples/js-edit/js/config/main.js
@@ -283,6 +283,7 @@
     }
 
     function isValidLibVersion(libUrl) {
+        var libKey = libUrl.split('/')[3];
         var libVersion = libUrl.split('/')[4];
 
         var infos = getLibsInfo();
@@ -298,7 +299,7 @@
         }
 
         return libs.some(function (lib) {
-            return lib.version === libVersion;
+            return lib.key === libKey && lib.version === libVersion;
         });
     }
 

--- a/examples/js-edit/manifest.json
+++ b/examples/js-edit/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 1,
-  "version": "4.5.1",
+  "version": "4.5.2",
   "type": "APP",
   "name": {
     "ja": "JSEdit for kintone",


### PR DESCRIPTION
* JavaScript/CSS カスタマイズにURLで登録したライブラリに、JSEditの下のチェックボックスで選択したCybozuCDNライブラリと同じものがあった場合に2つとも登録しないようにする
* JSEditの下のチェックが外れていたらJavaScript/CSSカスタマイズ からもURLを削除する

という機能（おそらく）の修正です。
